### PR TITLE
chore: upgrade base images and replace passlib with direct bcrypt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the React frontend
-FROM node:20-alpine AS frontend-build
+FROM node:22-alpine AS frontend-build
 WORKDIR /app
 COPY frontend/package*.json ./
 RUN npm install
@@ -7,7 +7,7 @@ COPY frontend/ .
 RUN npm run build
 
 # Stage 2: Python backend that also serves the built frontend
-FROM python:3.11-slim
+FROM python:3.12-slim
 WORKDIR /app
 
 COPY backend/requirements.txt .

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -8,8 +8,8 @@ from typing import Optional
 from uuid import uuid4
 
 from fastapi import Depends, HTTPException, Request, status
+import bcrypt as _bcrypt
 from jose import JWTError, jwt
-from passlib.context import CryptContext
 from sqlalchemy.orm import Session
 
 from . import crud, database
@@ -18,18 +18,16 @@ SECRET_KEY = os.getenv("SECRET_KEY", "change-me-in-production")
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60"))
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
 # In-memory revocation store (cleared on restart — acceptable for household app)
 _revoked_jtis: set = set()
 
 
 def hash_password(password: str) -> str:
-    return pwd_context.hash(password)
+    return _bcrypt.hashpw(password.encode(), _bcrypt.gensalt()).decode()
 
 
 def verify_password(plain: str, hashed: str) -> bool:
-    return pwd_context.verify(plain, hashed)
+    return _bcrypt.checkpw(plain.encode(), hashed.encode())
 
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,8 +6,7 @@ python-dotenv
 pydantic
 alembic
 python-jose[cryptography]
-passlib[bcrypt]
-bcrypt<4
+bcrypt
 python-multipart
 slowapi
 fpdf2


### PR DESCRIPTION
## Summary

- `node:20-alpine` → `node:22-alpine` (Active LTS, supported until April 2027) — closes #44
- `python:3.11-slim` → `python:3.12-slim` (full support until October 2028) — closes #45
- Replace `passlib[bcrypt]` with direct `bcrypt` calls in `auth.py`; removes the `bcrypt<4` pin — closes #43

## Notes

**bcrypt migration:** Existing stored password hashes are fully compatible — bcrypt hash format is unchanged. No data migration needed. `passlib` and the `bcrypt<4` constraint are both removed from `requirements.txt`.

## Test plan

- [ ] `docker compose up --build` completes without errors
- [ ] Login works with an existing account (verifies old hashes still validate)
- [ ] New account registration works (verifies new hashes are created correctly)
- [ ] App functions normally after rebuild