### PR TITLE
feat(frontend): migrate from react-router-dom v6 to react-router v7

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "axios": "^1.3.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.11.0"
+    "react-router": "^7.0.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Routes, Route, Link, useLocation, Navigate } from 'react-router-dom';
+import { Routes, Route, Link, useLocation, Navigate } from 'react-router';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import ProtectedRoute from './components/ProtectedRoute';
 import Today from './pages/Today';

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,6 +1,6 @@
 // frontend/src/components/ProtectedRoute.jsx
 import React from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { useAuth } from '../context/AuthContext';
 
 export default function ProtectedRoute({ children }) {

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,6 +1,6 @@
 // frontend/src/pages/Login.jsx
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import axios from 'axios';
 import { useAuth } from '../context/AuthContext';
 


### PR DESCRIPTION
## Summary

- Replaces `react-router-dom` (v6) with `react-router` (v7) — v7 ships DOM bindings in the main package
- Updates all 4 import sites: `App.jsx`, `index.jsx`, `ProtectedRoute.jsx`, `Login.jsx`
- No routing logic changes — v7 library mode is API-compatible with our v6 usage

## Test plan

- [ ] All routes load: `/`, `/refills`, `/history`, `/settings`, `/login`
- [ ] Unauthenticated users redirect to `/login`
- [ ] Login redirects back to `/`
- [ ] `<Navigate>`, `useNavigate`, `<Link>` all work as before

Closes #46