### PR TITLE
chore(frontend): upgrade vite 4→8 and @vitejs/plugin-react 4→6

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,10 +12,10 @@
     "react-router-dom": "^6.11.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.0.0",
+    "@vitejs/plugin-react": "^6.0.0",
     "autoprefixer": "^10.4.13",
     "postcss": "^8.4.21",
     "tailwindcss": "^3.2.7",
-    "vite": "^4.0.0"
+    "vite": "^8.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- Bumps `vite` from `^4.0.0` to `^8.0.0`
- Bumps `@vitejs/plugin-react` from `^4.0.0` to `^6.0.0` (requires Vite 6+)
- No config changes required — the `/api` proxy syntax in `vite.config.js` is stable across all Vite major versions

## Test plan

- [ ] Docker build succeeds (`npm install` + `npm run build` in container)
- [ ] Dev server starts without errors
- [ ] `/api` proxy forwards correctly to the FastAPI backend
- [ ] Built `dist/` is served correctly from FastAPI

Closes #47