### PR TITLE
feat(notifications): add email alerts for prescription expiration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,10 @@ POSTGRES_USER=medicabinet
 POSTGRES_DB=medicabinet_db
 SECRET_KEY=change-me-in-production
 ACCESS_TOKEN_EXPIRE_MINUTES=60
+
+# Email notifications (optional — leave blank to disable)
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASSWORD=
+SMTP_FROM=

--- a/backend/alembic/versions/0009_add_email_notifications.py
+++ b/backend/alembic/versions/0009_add_email_notifications.py
@@ -1,0 +1,29 @@
+"""add email notifications support
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-03-26
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("accounts", sa.Column("email", sa.String(), nullable=True))
+    op.add_column("prescriptions", sa.Column("expiration_date", sa.Date(), nullable=True))
+    op.add_column(
+        "notification_preferences",
+        sa.Column("email_enabled", sa.Boolean(), server_default="false", nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_column("accounts", "email")
+    op.drop_column("prescriptions", "expiration_date")
+    op.drop_column("notification_preferences", "email_enabled")

--- a/backend/email_service.py
+++ b/backend/email_service.py
@@ -1,0 +1,92 @@
+# backend/email_service.py
+# ------------------------
+# SMTP email delivery using stdlib smtplib.
+# All config comes from environment variables; sending is silently skipped
+# if SMTP_HOST is not set, so the app works without email configured.
+
+import os
+import smtplib
+import logging
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+
+logger = logging.getLogger(__name__)
+
+SMTP_HOST = os.getenv("SMTP_HOST", "")
+SMTP_PORT = int(os.getenv("SMTP_PORT", "587"))
+SMTP_USER = os.getenv("SMTP_USER", "")
+SMTP_PASSWORD = os.getenv("SMTP_PASSWORD", "")
+SMTP_FROM = os.getenv("SMTP_FROM", SMTP_USER)
+
+
+def _smtp_configured() -> bool:
+    return bool(SMTP_HOST and SMTP_USER and SMTP_PASSWORD)
+
+
+def send_email(to: str, subject: str, body_html: str, body_text: str) -> bool:
+    """Send an email. Returns True on success, False if skipped or on error."""
+    if not _smtp_configured():
+        logger.debug("SMTP not configured — skipping email to %s", to)
+        return False
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = subject
+    msg["From"] = SMTP_FROM
+    msg["To"] = to
+    msg.attach(MIMEText(body_text, "plain"))
+    msg.attach(MIMEText(body_html, "html"))
+
+    try:
+        with smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=10) as server:
+            server.ehlo()
+            server.starttls()
+            server.login(SMTP_USER, SMTP_PASSWORD)
+            server.sendmail(SMTP_FROM, [to], msg.as_string())
+        logger.info("Email sent to %s: %s", to, subject)
+        return True
+    except Exception:
+        logger.exception("Failed to send email to %s", to)
+        return False
+
+
+def send_prescription_expiry_warning(
+    to: str, username: str, expiring: list[dict]
+) -> bool:
+    """
+    Send a prescription expiry warning email.
+
+    expiring: list of dicts with keys: name, person, expiration_date, days_left
+    """
+    rows_html = "".join(
+        f"<tr><td>{r['person']}</td><td>{r['name']}</td>"
+        f"<td>{r['expiration_date']}</td><td>{r['days_left']} days</td></tr>"
+        for r in expiring
+    )
+    rows_text = "\n".join(
+        f"  {r['person']} — {r['name']} expires {r['expiration_date']} ({r['days_left']} days)"
+        for r in expiring
+    )
+
+    body_html = f"""
+    <p>Hi {username},</p>
+    <p>The following prescriptions in your Medicine Cabinet are expiring soon:</p>
+    <table border="1" cellpadding="6" cellspacing="0">
+      <thead><tr><th>Person</th><th>Medication</th><th>Expires</th><th>Days Left</th></tr></thead>
+      <tbody>{rows_html}</tbody>
+    </table>
+    <p>Log in to request renewals before they expire.</p>
+    """
+
+    body_text = (
+        f"Hi {username},\n\n"
+        "The following prescriptions are expiring soon:\n"
+        f"{rows_text}\n\n"
+        "Log in to request renewals before they expire."
+    )
+
+    return send_email(
+        to=to,
+        subject="Medicine Cabinet — Prescription Expiry Reminder",
+        body_html=body_html,
+        body_text=body_text,
+    )

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 # backend/main.py
 import os
+from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -11,10 +12,19 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from .routers import auth as auth_router
 from .routers import persons, medications, prescriptions, dose_logs, catalog, notifications, audit, contacts, calendar
 from .limiter import limiter
+from .scheduler import start_scheduler, stop_scheduler
 
 _frontend_dist = os.path.join(os.path.dirname(__file__), "..", "frontend", "dist")
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    start_scheduler()
+    yield
+    stop_scheduler()
+
+
+app = FastAPI(lifespan=lifespan)
 
 # Rate limiter
 app.state.limiter = limiter

--- a/backend/models.py
+++ b/backend/models.py
@@ -14,6 +14,7 @@ class Account(Base):
     username = Column(String, unique=True, index=True, nullable=False)
     hashed_password = Column(String, nullable=False)
     is_active = Column(Boolean, server_default="true", nullable=False)
+    email = Column(String, nullable=True)
 
     person_access = relationship("AccountPersonAccess", back_populates="account")
     dose_logs = relationship("DoseLog", back_populates="logged_by")
@@ -91,6 +92,7 @@ class Prescription(Base):
     scripts_remaining = Column(Integer, nullable=False, server_default="0")
     last_fill_date = Column(Date, nullable=True)
     next_eligible_date = Column(Date, nullable=True)
+    expiration_date = Column(Date, nullable=True)
     co_pay = Column(Numeric(8, 2), nullable=True)
     notes = Column(Text, nullable=True)
 
@@ -154,6 +156,7 @@ class NotificationPreference(Base):
     refill_reminder_days = Column(Integer, server_default="7", nullable=False)
     scripts_low_threshold = Column(Integer, server_default="2", nullable=False)
     calendar_token = Column(String, nullable=True, index=True)
+    email_enabled = Column(Boolean, server_default="false", nullable=False)
 
     account = relationship("Account", back_populates="notification_preference")
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,4 @@ python-multipart
 slowapi
 fpdf2
 icalendar
+apscheduler

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -73,3 +73,16 @@ def logout(request: Request, response: Response):
 @router.get("/me", response_model=schemas.AccountResponse)
 def me(account=Depends(get_current_account)):
     return account
+
+
+@router.patch("/me", response_model=schemas.AccountResponse)
+def update_me(
+    payload: schemas.AccountUpdate,
+    db: Session = Depends(database.get_db),
+    account=Depends(get_current_account),
+):
+    for field, value in payload.dict(exclude_unset=True).items():
+        setattr(account, field, value)
+    db.commit()
+    db.refresh(account)
+    return account

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -1,0 +1,83 @@
+# backend/scheduler.py
+# --------------------
+# APScheduler background job: daily prescription expiry email alerts.
+# Runs at 09:00 server time.  Skipped silently if SMTP is not configured.
+
+import logging
+from datetime import date, timedelta
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+from .database import SessionLocal
+from . import models
+from .email_service import send_prescription_expiry_warning
+
+logger = logging.getLogger(__name__)
+
+WARN_DAYS = (7, 30)
+
+scheduler = AsyncIOScheduler()
+
+
+def _check_expiring_prescriptions() -> None:
+    """Query all accounts with email alerts enabled and send reminders."""
+    today = date.today()
+    thresholds = {today + timedelta(days=d) for d in WARN_DAYS}
+
+    db = SessionLocal()
+    try:
+        prefs = (
+            db.query(models.NotificationPreference)
+            .filter(models.NotificationPreference.email_enabled.is_(True))
+            .all()
+        )
+
+        for pref in prefs:
+            account = pref.account
+            if not account or not account.email or not account.is_active:
+                continue
+
+            expiring = []
+            for access in account.person_access:
+                person = access.person
+                for med in person.medications:
+                    if not med.is_active or not med.prescription:
+                        continue
+                    exp = med.prescription.expiration_date
+                    if exp and exp in thresholds:
+                        days_left = (exp - today).days
+                        expiring.append({
+                            "person": person.name,
+                            "name": med.name,
+                            "expiration_date": exp.isoformat(),
+                            "days_left": days_left,
+                        })
+
+            if expiring:
+                send_prescription_expiry_warning(
+                    to=account.email,
+                    username=account.username,
+                    expiring=expiring,
+                )
+    except Exception:
+        logger.exception("Error during prescription expiry check")
+    finally:
+        db.close()
+
+
+def start_scheduler() -> None:
+    scheduler.add_job(
+        _check_expiring_prescriptions,
+        trigger="cron",
+        hour=9,
+        minute=0,
+        id="prescription_expiry_check",
+        replace_existing=True,
+    )
+    scheduler.start()
+    logger.info("Scheduler started")
+
+
+def stop_scheduler() -> None:
+    scheduler.shutdown(wait=False)
+    logger.info("Scheduler stopped")

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -32,10 +32,14 @@ class AccountCreate(BaseModel):
             raise ValueError("Password must contain at least one special character")
         return v
 
+class AccountUpdate(BaseModel):
+    email: Optional[str] = Field(None, max_length=254)
+
 class AccountResponse(BaseModel):
     id: int
     username: str
     is_active: bool
+    email: Optional[str]
 
     class Config:
         orm_mode = True
@@ -137,6 +141,7 @@ class PrescriptionCreate(BaseModel):
     scripts_remaining: int = 0
     last_fill_date: Optional[date] = None
     next_eligible_date: Optional[date] = None
+    expiration_date: Optional[date] = None
     co_pay: Optional[Decimal] = None
     notes: Optional[str] = Field(None, max_length=2000)
 
@@ -147,6 +152,7 @@ class PrescriptionUpdate(BaseModel):
     scripts_remaining: Optional[int] = None
     last_fill_date: Optional[date] = None
     next_eligible_date: Optional[date] = None
+    expiration_date: Optional[date] = None
     co_pay: Optional[Decimal] = None
     notes: Optional[str] = Field(None, max_length=2000)
 
@@ -159,6 +165,7 @@ class PrescriptionResponse(BaseModel):
     scripts_remaining: int
     last_fill_date: Optional[date]
     next_eligible_date: Optional[date]
+    expiration_date: Optional[date]
     co_pay: Optional[Decimal]
     notes: Optional[str]
 
@@ -224,6 +231,7 @@ class NotificationPrefUpdate(BaseModel):
     ntfy_token: Optional[str] = Field(None, max_length=500)
     refill_reminder_days: Optional[int] = None
     scripts_low_threshold: Optional[int] = None
+    email_enabled: Optional[bool] = None
 
 class NotificationPrefResponse(BaseModel):
     id: int
@@ -233,6 +241,7 @@ class NotificationPrefResponse(BaseModel):
     refill_reminder_days: int
     scripts_low_threshold: int
     calendar_token: Optional[str]
+    email_enabled: bool
 
     class Config:
         orm_mode = True

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -453,7 +453,7 @@ function PrescriptionsTab() {
   const [form, setForm]                   = useState({
     medication_id: '', prescriber: '', pharmacy: '',
     days_supply: 30, scripts_remaining: 6,
-    last_fill_date: '', next_eligible_date: '', co_pay: '',
+    last_fill_date: '', next_eligible_date: '', expiration_date: '', co_pay: '',
   });
   const [providerSuggestions, setProviderSuggestions] = useState([]);
   const [pharmacySuggestions, setPharmacySuggestions] = useState([]);
@@ -489,7 +489,7 @@ function PrescriptionsTab() {
     setModal('add');
     setProviderSuggestions([]);
     setPharmacySuggestions([]);
-    setForm({ medication_id: '', prescriber: '', pharmacy: '', days_supply: 30, scripts_remaining: 6, last_fill_date: '', next_eligible_date: '', co_pay: '' });
+    setForm({ medication_id: '', prescriber: '', pharmacy: '', days_supply: 30, scripts_remaining: 6, last_fill_date: '', next_eligible_date: '', expiration_date: '', co_pay: '' });
   }
 
   function openEdit(rx) {
@@ -505,6 +505,7 @@ function PrescriptionsTab() {
       scripts_remaining: rx.scripts_remaining,
       last_fill_date: rx.last_fill_date || '',
       next_eligible_date: rx.next_eligible_date || '',
+      expiration_date: rx.expiration_date || '',
       co_pay: rx.co_pay != null ? String(rx.co_pay) : '',
     });
   }
@@ -531,6 +532,7 @@ function PrescriptionsTab() {
         scripts_remaining: Number(form.scripts_remaining),
         last_fill_date: form.last_fill_date || undefined,
         next_eligible_date: form.next_eligible_date || undefined,
+        expiration_date: form.expiration_date || undefined,
         co_pay: form.co_pay !== '' ? Number(form.co_pay) : undefined,
       };
       if (modal === 'add') {
@@ -691,6 +693,9 @@ function PrescriptionsTab() {
               <Input type="date" value={form.next_eligible_date} onChange={e => setForm(f => ({ ...f, next_eligible_date: e.target.value }))} />
             </Field>
           </div>
+          <Field label="Prescription expiration date">
+            <Input type="date" value={form.expiration_date} onChange={e => setForm(f => ({ ...f, expiration_date: e.target.value }))} />
+          </Field>
 
           <div className="flex justify-end gap-3 pt-2">
             <button onClick={() => setModal(null)} className="px-4 py-2 text-sm text-gray-600">Cancel</button>
@@ -711,23 +716,29 @@ function PrescriptionsTab() {
 // ── Notifications tab ──────────────────────────────────────────────────────────
 function NotificationsTab() {
   const [prefs, setPrefs]         = useState(null);
-  const [form, setForm]           = useState({ ntfy_url: '', ntfy_token: '', refill_reminder_days: 7, scripts_low_threshold: 2 });
+  const [form, setForm]           = useState({ ntfy_url: '', ntfy_token: '', refill_reminder_days: 7, scripts_low_threshold: 2, email_enabled: false });
+  const [email, setEmail]         = useState('');
   const [saving, setSaving]       = useState(false);
   const [saved, setSaved]         = useState(false);
   const [subscribeUrl, setSubscribeUrl] = useState(null);
   const [tokenGenerating, setTokenGenerating] = useState(false);
 
   useEffect(() => {
-    axios.get('/api/notifications/preferences').then(r => {
-      setPrefs(r.data);
+    Promise.all([
+      axios.get('/api/notifications/preferences'),
+      axios.get('/api/auth/me'),
+    ]).then(([prefsRes, meRes]) => {
+      setPrefs(prefsRes.data);
       setForm({
-        ntfy_url: r.data.ntfy_url || '',
-        ntfy_token: r.data.ntfy_token || '',
-        refill_reminder_days: r.data.refill_reminder_days,
-        scripts_low_threshold: r.data.scripts_low_threshold,
+        ntfy_url: prefsRes.data.ntfy_url || '',
+        ntfy_token: prefsRes.data.ntfy_token || '',
+        refill_reminder_days: prefsRes.data.refill_reminder_days,
+        scripts_low_threshold: prefsRes.data.scripts_low_threshold,
+        email_enabled: prefsRes.data.email_enabled,
       });
-      if (r.data.calendar_token) {
-        setSubscribeUrl(`${window.location.origin}/api/calendar/subscribe.ics?token=${r.data.calendar_token}`);
+      setEmail(meRes.data.email || '');
+      if (prefsRes.data.calendar_token) {
+        setSubscribeUrl(`${window.location.origin}/api/calendar/subscribe.ics?token=${prefsRes.data.calendar_token}`);
       }
     });
   }, []);
@@ -745,12 +756,16 @@ function NotificationsTab() {
   async function save() {
     setSaving(true);
     try {
-      await axios.patch('/api/notifications/preferences', {
-        ntfy_url: form.ntfy_url || null,
-        ntfy_token: form.ntfy_token || null,
-        refill_reminder_days: Number(form.refill_reminder_days),
-        scripts_low_threshold: Number(form.scripts_low_threshold),
-      });
+      await Promise.all([
+        axios.patch('/api/notifications/preferences', {
+          ntfy_url: form.ntfy_url || null,
+          ntfy_token: form.ntfy_token || null,
+          refill_reminder_days: Number(form.refill_reminder_days),
+          scripts_low_threshold: Number(form.scripts_low_threshold),
+          email_enabled: form.email_enabled,
+        }),
+        axios.patch('/api/auth/me', { email: email || null }),
+      ]);
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     } finally {
@@ -762,6 +777,31 @@ function NotificationsTab() {
 
   return (
     <div className="space-y-5 max-w-md">
+      <div>
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3">Email notifications</h3>
+        <div className="space-y-3">
+          <Field label="Email address">
+            <Input
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              placeholder="you@example.com"
+            />
+          </Field>
+          <label className="flex items-center gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={form.email_enabled}
+              onChange={e => setForm(f => ({ ...f, email_enabled: e.target.checked }))}
+              className="w-4 h-4 accent-blue-600"
+            />
+            <span className="text-sm text-gray-700 dark:text-gray-200">
+              Send email alerts 7 and 30 days before prescription expiration
+            </span>
+          </label>
+        </div>
+      </div>
+
       <div>
         <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3">ntfy push notifications</h3>
         <div className="space-y-3">


### PR DESCRIPTION
## Summary

- **Email address** on Account: stored in the DB, editable via `PATCH /api/auth/me`
- **Prescription expiration date**: new `expiration_date` field on Prescription model + form field in Settings → Prescriptions tab
- **APScheduler cron job**: runs daily at 09:00, queries all accounts with `email_enabled = true` and sends a reminder 7 and 30 days before each prescription's `expiration_date`
- **SMTP delivery**: pure stdlib `smtplib` — no extra Python package needed; sending is silently skipped if `SMTP_HOST` is not set
- **Settings UI**: new "Email notifications" section in Notifications tab — email address input + checkbox to enable alerts

## New env vars (all optional — omit to disable email)

```
SMTP_HOST=
SMTP_PORT=587
SMTP_USER=
SMTP_PASSWORD=
SMTP_FROM=
```

## Files changed

| File | Change |
|------|--------|
| `backend/models.py` | `email` on Account; `expiration_date` on Prescription; `email_enabled` on NotificationPreference |
| `backend/schemas.py` | `AccountUpdate`, updated `PrescriptionCreate/Update/Response`, updated `NotificationPrefUpdate/Response` |
| `backend/routers/auth.py` | `PATCH /api/auth/me` endpoint |
| `backend/alembic/versions/0009_…` | Migration for the three new columns |
| `backend/email_service.py` | SMTP send helpers |
| `backend/scheduler.py` | APScheduler job |
| `backend/main.py` | FastAPI lifespan wires up scheduler |
| `backend/requirements.txt` | `apscheduler` added |
| `frontend/src/pages/Settings.jsx` | Email field + toggle in Notifications tab; expiration date field in Prescriptions tab |
| `.env.example` | SMTP var documentation |

## Test plan

- [ ] Docker build succeeds
- [ ] Migration 0009 runs cleanly on a fresh DB
- [ ] Can set email address and save in Settings → Notifications
- [ ] Email alerts checkbox saves and reloads correctly
- [ ] Prescription expiration date field saves and displays in Settings → Prescriptions
- [ ] With SMTP configured: set a prescription expiration to today+7, confirm email arrives at 09:00
- [ ] Without SMTP configured: no errors on startup or during the cron job

Closes #13