### PR TITLE
feat(account): add username and password management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Dependabot Updates](https://github.com/snachodog/medicine-cabinet/actions/workflows/dependabot/dependabot-updates/badge.svg?branch=main)](https://github.com/snachodog/medicine-cabinet/actions/workflows/dependabot/dependabot-updates)
+
 # Medicine Cabinet
 
 **Medicine Cabinet** is a self-hosted web app for tracking your household's medications, prescriptions, and dose history — running entirely on your own server.

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -160,11 +160,37 @@ def me(account=Depends(get_current_account)):
 @router.patch("/me", response_model=schemas.AccountResponse)
 def update_me(
     payload: schemas.AccountUpdate,
+    response: Response,
     db: Session = Depends(database.get_db),
     account=Depends(get_current_account),
 ):
-    for field, value in payload.dict(exclude_unset=True).items():
+    data = payload.dict(exclude_unset=True)
+    if "username" in data and data["username"] != account.username:
+        if crud.get_account_by_username(db, data["username"]):
+            raise HTTPException(status_code=400, detail="Username already taken")
+    for field, value in data.items():
         setattr(account, field, value)
     db.commit()
     db.refresh(account)
+    if "username" in data:
+        token = create_access_token({"sub": account.username})
+        response.set_cookie(
+            key="mc_token",
+            value=token,
+            httponly=True,
+            max_age=ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+            samesite="lax",
+        )
     return account
+
+
+@router.post("/me/password", status_code=204)
+def change_password(
+    payload: schemas.PasswordChange,
+    db: Session = Depends(database.get_db),
+    account=Depends(get_current_account),
+):
+    if not verify_password(payload.current_password, account.hashed_password):
+        raise HTTPException(status_code=400, detail="Current password is incorrect")
+    account.hashed_password = hash_password(payload.new_password)
+    db.commit()

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -35,6 +35,31 @@ class AccountCreate(BaseModel):
 
 class AccountUpdate(BaseModel):
     email: Optional[str] = Field(None, max_length=254)
+    username: Optional[str] = Field(None, min_length=3, max_length=50)
+
+    @validator("username")
+    def username_valid(cls, v):
+        if v and not re.match(r"^[a-zA-Z0-9_.\-]+$", v):
+            raise ValueError("Username may only contain letters, numbers, underscores, hyphens, and dots")
+        return v
+
+class PasswordChange(BaseModel):
+    current_password: str
+    new_password: str
+
+    @validator("new_password")
+    def password_strength(cls, v):
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters")
+        if not re.search(r"[A-Z]", v):
+            raise ValueError("Password must contain at least one uppercase letter")
+        if not re.search(r"[a-z]", v):
+            raise ValueError("Password must contain at least one lowercase letter")
+        if not re.search(r"\d", v):
+            raise ValueError("Password must contain at least one number")
+        if not re.search(r"[^A-Za-z0-9]", v):
+            raise ValueError("Password must contain at least one special character")
+        return v
 
 class AccountResponse(BaseModel):
     id: int

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import Modal from '../components/Modal';
 import { useAuth } from '../context/AuthContext';
 
-const TABS = ['Persons', 'Medications', 'Prescriptions', 'Contacts', 'Notifications', 'Invites', 'Activity'];
+const TABS = ['Persons', 'Medications', 'Prescriptions', 'Contacts', 'Notifications', 'Invites', 'Account', 'Activity'];
 const SCHEDULES = ['morning', 'twice_daily', 'evening', 'three_times_daily', 'every_other_day', 'weekly', 'monthly', 'as_needed'];
 const SCHEDULE_LABEL_MAP = {
   morning: 'Morning', twice_daily: 'Twice Daily', evening: 'Evening',
@@ -1198,10 +1198,110 @@ function InvitesTab() {
   );
 }
 
+// ── Account tab ────────────────────────────────────────────────────────────────
+function AccountTab() {
+  const { account, login } = useAuth();
+  const [username, setUsername] = useState('');
+  const [usernameSaving, setUsernameSaving] = useState(false);
+  const [usernameMsg, setUsernameMsg] = useState(null); // { ok, text }
+
+  const [pw, setPw] = useState({ current: '', next: '', confirm: '' });
+  const [pwSaving, setPwSaving] = useState(false);
+  const [pwMsg, setPwMsg] = useState(null);
+
+  useEffect(() => {
+    if (account) setUsername(account.username);
+  }, [account]);
+
+  async function saveUsername() {
+    setUsernameSaving(true);
+    setUsernameMsg(null);
+    try {
+      const res = await axios.patch('/api/auth/me', { username });
+      login(res.data);
+      setUsernameMsg({ ok: true, text: 'Username updated.' });
+    } catch (e) {
+      setUsernameMsg({ ok: false, text: e.response?.data?.detail || 'Could not update username.' });
+    } finally {
+      setUsernameSaving(false);
+    }
+  }
+
+  async function savePassword(e) {
+    e.preventDefault();
+    if (pw.next !== pw.confirm) {
+      setPwMsg({ ok: false, text: 'New passwords do not match.' });
+      return;
+    }
+    setPwSaving(true);
+    setPwMsg(null);
+    try {
+      await axios.post('/api/auth/me/password', { current_password: pw.current, new_password: pw.next });
+      setPw({ current: '', next: '', confirm: '' });
+      setPwMsg({ ok: true, text: 'Password changed.' });
+    } catch (e) {
+      setPwMsg({ ok: false, text: e.response?.data?.detail || 'Could not change password.' });
+    } finally {
+      setPwSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-8 max-w-md">
+      <div>
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3">Username</h3>
+        <div className="flex gap-2">
+          <Input
+            value={username}
+            onChange={e => setUsername(e.target.value)}
+            placeholder="Username"
+            className="flex-1"
+          />
+          <button
+            onClick={saveUsername}
+            disabled={usernameSaving || username === account?.username}
+            className="px-4 py-2 bg-blue-600 text-white text-sm rounded-lg disabled:opacity-50"
+          >
+            {usernameSaving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+        {usernameMsg && (
+          <p className={`mt-2 text-sm ${usernameMsg.ok ? 'text-green-600' : 'text-red-500'}`}>{usernameMsg.text}</p>
+        )}
+      </div>
+
+      <div>
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3">Change password</h3>
+        <form onSubmit={savePassword} className="space-y-3">
+          <Field label="Current password">
+            <Input type="password" value={pw.current} onChange={e => setPw(p => ({ ...p, current: e.target.value }))} autoComplete="current-password" required />
+          </Field>
+          <Field label="New password">
+            <Input type="password" value={pw.next} onChange={e => setPw(p => ({ ...p, next: e.target.value }))} autoComplete="new-password" required />
+          </Field>
+          <Field label="Confirm new password">
+            <Input type="password" value={pw.confirm} onChange={e => setPw(p => ({ ...p, confirm: e.target.value }))} autoComplete="new-password" required />
+          </Field>
+          {pwMsg && (
+            <p className={`text-sm ${pwMsg.ok ? 'text-green-600' : 'text-red-500'}`}>{pwMsg.text}</p>
+          )}
+          <button
+            type="submit"
+            disabled={pwSaving}
+            className="px-4 py-2 bg-blue-600 text-white text-sm rounded-lg disabled:opacity-50"
+          >
+            {pwSaving ? 'Saving…' : 'Change password'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
 // ── Main Settings page ─────────────────────────────────────────────────────────
 export default function Settings() {
   const [tab, setTab] = useState(0);
-  const CONTENT = [<PersonsTab />, <MedicationsTab />, <PrescriptionsTab />, <ContactsTab />, <NotificationsTab />, <InvitesTab />, <ActivityTab />];
+  const CONTENT = [<PersonsTab />, <MedicationsTab />, <PrescriptionsTab />, <ContactsTab />, <NotificationsTab />, <InvitesTab />, <AccountTab />, <ActivityTab />];
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary

- Adds an **Account** tab to Settings with two sections:
  - **Username** — change your username (validates uniqueness; re-issues JWT cookie so the session stays valid after the rename)
  - **Change password** — requires current password confirmation; enforces the same strength rules as registration (uppercase, lowercase, digit, special char, 8+ chars)
- Backend: new `POST /api/auth/me/password` endpoint; `PATCH /api/auth/me` extended to handle username updates with conflict detection and token refresh
- Backend: `AccountUpdate` schema extended with `username` field (with format validation); new `PasswordChange` schema with strength validation
- Also includes Dependabot badge in README

Closes #61