### PR TITLE
fix: prescription list crash, invite code white screen, mobile login

### DIFF
--- a/backend/routers/prescriptions.py
+++ b/backend/routers/prescriptions.py
@@ -1,4 +1,5 @@
 # backend/routers/prescriptions.py
+from datetime import date
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from typing import List

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -44,12 +44,13 @@ export default function Login() {
         login(res.data);
         navigate('/');
       } else {
-        await axios.post('/api/auth/register', form);
+        await axios.post('/api/auth/register', { ...form, invite_code: form.invite_code || null });
         setTab('login');
         setError('Account created — please sign in.');
       }
     } catch (err) {
-      setError(err.response?.data?.detail ?? 'Something went wrong.');
+      const detail = err.response?.data?.detail;
+      setError(Array.isArray(detail) ? detail.map(e => e.msg).join(' ') : (detail ?? 'Something went wrong.'));
     } finally {
       setSubmitting(false);
     }
@@ -93,7 +94,7 @@ export default function Login() {
             placeholder="Username"
             autoComplete="username"
             required
-            className="block w-full p-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
+            className="block w-full px-3 py-3 text-base border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
           />
           <input
             type="password"
@@ -103,7 +104,7 @@ export default function Login() {
             placeholder="Password"
             autoComplete={tab === 'login' ? 'current-password' : 'new-password'}
             required
-            className="block w-full p-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
+            className="block w-full px-3 py-3 text-base border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
           />
           {tab === 'register' && (
             <input
@@ -112,13 +113,13 @@ export default function Login() {
               onChange={handleChange}
               placeholder={config.registration_enabled ? 'Invite code (optional)' : 'Invite code (required)'}
               required={!config.registration_enabled}
-              className="block w-full p-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
+              className="block w-full px-3 py-3 text-base border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
             />
           )}
           <button
             type="submit"
             disabled={submitting}
-            className="w-full py-2 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:opacity-50"
+            className="w-full py-3 text-base bg-blue-500 text-white rounded hover:bg-blue-600 disabled:opacity-50"
           >
             {submitting ? 'Please wait…' : tab === 'login' ? 'Sign In' : 'Create Account'}
           </button>
@@ -133,7 +134,7 @@ export default function Login() {
             </div>
             <a
               href="/api/auth/oidc/login"
-              className="flex items-center justify-center w-full py-2 border border-gray-300 dark:border-gray-600 rounded text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+              className="flex items-center justify-center w-full py-3 text-base border border-gray-300 dark:border-gray-600 rounded text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
             >
               Sign in with {config.oidc_provider_name}
             </a>


### PR DESCRIPTION
## Fixes

### #67 — Prescription list crashes when any prescription has no dates

`date.max` was referenced in the sort key but `date` was never imported in `prescriptions.py`. Any prescription with a null `next_eligible_date` caused a `NameError` that crashed the entire list endpoint, making all prescriptions disappear.

Fix: `from datetime import date`

### #68 — White screen when registering with an invite code

Two problems:
1. Pydantic returns `detail` as an array of objects on 422 validation errors. The frontend passed that array directly to `setError`, then React tried to render objects as children and crashed with "Objects are not valid as a React child".
2. An empty invite code field was sent as `""` (empty string) rather than `null`, which could trip schema validators unnecessarily.

Fix: flatten the array to a string in the catch block; send `invite_code: null` when the field is empty.

### #69 — Login form too small on mobile

Inputs used `p-2` with no explicit font size, causing iOS to auto-zoom (anything under 16px triggers zoom). Buttons were also undersized for touch targets.

Fix: all inputs and buttons now use `py-3` and `text-base` (16px) throughout the login page.

### #70 — PDF not updating after medication changes

Already resolved by `Cache-Control: no-store` added in #66. Closing via comment.

Closes #67
Closes #68
Closes #69