### PR TITLE
feat(pwa): add Progressive Web App support

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,16 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Medicine Cabinet</title>
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="icon" href="/icon.svg" type="image/svg+xml" />
+    <meta name="theme-color" content="#2563eb" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="Med Cabinet" />
+    <link rel="apple-touch-icon" href="/icon.svg" />
     <script>
       if (localStorage.getItem('theme') === 'dark') {
         document.documentElement.classList.add('dark');

--- a/frontend/public/icon.svg
+++ b/frontend/public/icon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="112" fill="#2563eb"/>
+  <clipPath id="lhalf">
+    <rect x="0" y="0" width="256" height="512"/>
+  </clipPath>
+  <!-- Pill: white base -->
+  <rect x="126" y="191" width="260" height="130" rx="65" fill="white"/>
+  <!-- Pill: light-blue left half -->
+  <rect x="126" y="191" width="260" height="130" rx="65" fill="#bfdbfe" clip-path="url(#lhalf)"/>
+  <!-- Divider -->
+  <rect x="253" y="191" width="6" height="130" fill="#2563eb"/>
+</svg>

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -1,0 +1,25 @@
+{
+  "name": "Medicine Cabinet",
+  "short_name": "Med Cabinet",
+  "description": "Track medications and doses for your household",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "theme_color": "#2563eb",
+  "background_color": "#f3f4f6",
+  "icons": [
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,58 @@
+const CACHE = 'mc-v1';
+
+// Static assets to precache on install
+const PRECACHE = ['/'];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE).then(cache => cache.addAll(PRECACHE))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Never intercept API calls or non-GET requests — always go to network
+  if (request.method !== 'GET' || url.pathname.startsWith('/api/')) {
+    return;
+  }
+
+  // Navigation requests: network first, fall back to cached shell
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .then(response => {
+          const clone = response.clone();
+          caches.open(CACHE).then(cache => cache.put(request, clone));
+          return response;
+        })
+        .catch(() => caches.match('/'))
+    );
+    return;
+  }
+
+  // Static assets: cache first, then network
+  event.respondWith(
+    caches.match(request).then(cached => {
+      if (cached) return cached;
+      return fetch(request).then(response => {
+        if (response.ok) {
+          const clone = response.clone();
+          caches.open(CACHE).then(cache => cache.put(request, clone));
+        }
+        return response;
+      });
+    })
+  );
+});

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -6,6 +6,12 @@ import App from './App';
 import './index.css';
 import { BrowserRouter } from 'react-router';
 
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js');
+  });
+}
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary

- Add `manifest.webmanifest` - app name, standalone display mode, theme color, icon
- Add `sw.js` - service worker with cache-first for static assets, network-first for navigation, and API calls always bypass the cache entirely
- Add `icon.svg` - pill capsule icon on blue rounded-square background
- Update `index.html` with viewport meta, manifest link, `theme-color`, and Apple PWA meta tags
- Register service worker in `index.jsx`

## What this enables

- **Install to home screen** on Android (Chrome) and iOS (Safari) - users get a native-feeling app icon
- **Standalone display** - runs without browser chrome (address bar, back button) when launched from home screen
- **Offline shell** - the app shell loads from cache if the network is unavailable; API data still requires connectivity
- **Faster repeat loads** - static assets served from cache after first visit

## Notes

- `vite-plugin-pwa` was evaluated but does not yet support Vite 8; implemented manually instead
- API calls (`/api/*`) are never cached - medication data always comes from the server
- The service worker cache key is `mc-v1`; bump this string to force a cache refresh on next deploy
- iOS Safari does not show the install prompt automatically - users must use "Add to Home Screen" from the share menu

## Test plan

- [ ] Open in Chrome, verify install prompt appears in address bar
- [ ] Install to Android home screen, launch and confirm standalone display (no browser chrome)
- [ ] Open on iOS Safari, use Share > Add to Home Screen, confirm icon and app name
- [ ] Confirm API calls (logging a dose) work normally after install
- [ ] Open DevTools > Application > Manifest - verify all fields parse correctly
- [ ] Open DevTools > Application > Service Workers - verify SW registered and active