### PR TITLE
feat(ux): improve empty states and new-user guidance

### DIFF
--- a/frontend/src/pages/History.jsx
+++ b/frontend/src/pages/History.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
+import { Link } from 'react-router';
 import axios from 'axios';
 
 function daysAgo(n) {
@@ -83,6 +84,11 @@ export default function History() {
 
   return (
     <div className="space-y-6">
+      <div className="flex items-baseline justify-between">
+        <h2 className="text-lg font-semibold text-gray-700 dark:text-gray-200">History</h2>
+        <span className="text-xs text-gray-400 dark:text-gray-500">Last 30 days</span>
+      </div>
+
       {/* Person tabs */}
       {persons.length > 1 && (
         <div className="flex gap-2 flex-wrap">
@@ -105,7 +111,15 @@ export default function History() {
       {error && <p className="text-red-500 text-sm">{error}</p>}
 
       {meds.length === 0 && !error && (
-        <p className="text-gray-400 dark:text-gray-500 text-sm">No medications found.</p>
+        <div className="text-center py-10">
+          <p className="text-gray-400 dark:text-gray-500 text-sm mb-3">No medications found. Add medications to start tracking dose history.</p>
+          <Link
+            to="/settings"
+            className="inline-block px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 transition-colors"
+          >
+            Go to Settings
+          </Link>
+        </div>
       )}
 
       <ul className="space-y-3">

--- a/frontend/src/pages/Refills.jsx
+++ b/frontend/src/pages/Refills.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router';
 import axios from 'axios';
 import Modal from '../components/Modal';
 
@@ -82,7 +83,16 @@ export default function Refills() {
       {error && <p className="text-red-500 text-sm">{error}</p>}
 
       {prescriptions.length === 0 && !error && (
-        <p className="text-gray-400 dark:text-gray-500 text-sm">No prescriptions tracked. Add Rx medications in Settings.</p>
+        <div className="text-center py-10">
+          <p className="text-gray-400 dark:text-gray-500 text-sm mb-1">No prescriptions tracked.</p>
+          <p className="text-gray-400 dark:text-gray-500 text-xs mb-3">Add a medication with type set to "Prescription" to start tracking refills.</p>
+          <Link
+            to="/settings"
+            className="inline-block px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 transition-colors"
+          >
+            Go to Settings
+          </Link>
+        </div>
       )}
 
       <ul className="space-y-3">

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -458,6 +458,9 @@ function MedicationsTab() {
               <Select value={form.type} onChange={e => setForm(f => ({ ...f, type: e.target.value }))}>
                 {MED_TYPES.map(t => <option key={t} value={t}>{TYPE_LABEL[t]}</option>)}
               </Select>
+              {form.type === 'rx' && (
+                <p className="mt-1 text-xs text-blue-600 dark:text-blue-400">Prescription medications appear in the Refills tracker.</p>
+              )}
             </Field>
             <Field label="Schedule">
               <Select value={form.schedule} onChange={e => setForm(f => ({ ...f, schedule: e.target.value }))}>

--- a/frontend/src/pages/Today.jsx
+++ b/frontend/src/pages/Today.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
+import { Link } from 'react-router';
 import axios from 'axios';
 
 const SCHEDULE_ORDER = ['morning', 'twice_daily', 'evening', 'three_times_daily', 'every_other_day', 'weekly', 'monthly', 'as_needed'];
@@ -154,7 +155,15 @@ export default function Today() {
       {error && <p className="text-red-500 text-sm">{error}</p>}
 
       {meds.length === 0 && !error && (
-        <p className="text-gray-400 dark:text-gray-500 text-sm">No active medications. Add some in Settings.</p>
+        <div className="text-center py-10">
+          <p className="text-gray-400 dark:text-gray-500 text-sm mb-3">No active medications yet.</p>
+          <Link
+            to="/settings"
+            className="inline-block px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 transition-colors"
+          >
+            Add medications in Settings
+          </Link>
+        </div>
       )}
 
       {/* Scheduled medication groups */}


### PR DESCRIPTION
## Summary

- **Today, Refills, History** empty states replaced with centered layout + "Go to Settings" button - eliminates the dead-end gray text new users hit on first login
- **Refills** empty state also explains that medications must have type "Prescription" to appear here
- **History** header now shows "Last 30 days" so users understand the data scope
- **Medication type selector** shows a contextual hint when "Prescription" is selected: "Prescription medications appear in the Refills tracker"

## Test plan

- [ ] New account with no data: verify Today, Refills, History each show the button and it navigates to Settings
- [ ] Add a non-Rx medication: verify Refills still shows empty state with type explanation
- [ ] Add an Rx medication: verify Refills populates and History shows "Last 30 days" label
- [ ] Open medication add/edit modal, change type to Prescription: verify blue hint appears
- [ ] Change type away from Prescription: verify hint disappears