### PR TITLE
feat(footer): add GitHub link and commit hash to all pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -138,6 +138,29 @@ function AppShell() {
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </main>
+
+      <footer className="max-w-3xl mx-auto px-4 py-4 mt-2 flex items-center justify-end gap-2 border-t border-gray-200 dark:border-gray-800">
+        <a
+          href="https://github.com/snachodog/medicine-cabinet"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+          aria-label="View source on GitHub"
+        >
+          <svg viewBox="0 0 24 24" className="w-4 h-4" fill="currentColor" aria-hidden="true">
+            <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+          </svg>
+        </a>
+        <a
+          href={`https://github.com/snachodog/medicine-cabinet/commit/${__COMMIT_HASH__}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-mono text-xs text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+          title="View this build's commit on GitHub"
+        >
+          {__COMMIT_HASH__}
+        </a>
+      </footer>
     </div>
   );
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,9 +1,21 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { execSync } from 'child_process'
+
+const commitHash = (() => {
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim();
+  } catch {
+    return 'unknown';
+  }
+})();
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: {
+    __COMMIT_HASH__: JSON.stringify(commitHash),
+  },
   server: {
     proxy: {
       '/api': {


### PR DESCRIPTION
## Summary

- Every page now has a subtle footer (right-aligned, below the main content area) showing:
  - GitHub mark icon linking to the repository
  - Short commit hash (e.g. `8bd7668`) linking directly to that commit on GitHub
- Commit hash is injected at build time via `vite.config.js` using `execSync('git rev-parse --short HEAD')`
- Falls back to `"unknown"` if git is not available during build (e.g. in a clean CI environment without git history)
- Footer is visible on all pages including the login screen

## How it helps troubleshooting
When a user reports a bug, you can ask them to check the footer to confirm exactly which build they're running. Clicking the hash takes you directly to the commit on GitHub.

## Test plan
- [ ] Run `npm run dev` locally - footer shows a real short hash
- [ ] Click the GitHub logo - opens repo in new tab
- [ ] Click the hash - opens the correct commit on GitHub
- [ ] Build the Docker image and confirm the hash baked into the build matches `git rev-parse --short HEAD` at build time
- [ ] Verify footer appears on Today, Refills, History, Settings, and Login pages