### PR TITLE
fix(medications): delete fails when dose logs or prescription exist

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -150,6 +150,13 @@ def delete_medication(db: Session, medication_id: int):
     med = db.query(models.Medication).filter(models.Medication.id == medication_id).first()
     if med is None:
         return None
+    # Remove dose logs referencing this medication
+    db.query(models.DoseLog).filter(models.DoseLog.medication_id == medication_id).delete()
+    # Remove fills and prescription if one exists
+    rx = db.query(models.Prescription).filter(models.Prescription.medication_id == medication_id).first()
+    if rx:
+        db.query(models.Fill).filter(models.Fill.prescription_id == rx.id).delete()
+        db.delete(rx)
     db.delete(med)
     db.commit()
     return med

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -375,10 +375,14 @@ function MedicationsTab() {
   }
 
   async function deleteMed(m) {
-    if (!confirm(`Permanently delete "${m.name}"? This cannot be undone.`)) return;
-    await axios.delete(`/api/medications/${m.id}`);
-    setModal(null);
-    loadMeds();
+    if (!confirm(`Permanently delete "${m.name}"? This will also remove all dose history for this medication. This cannot be undone.`)) return;
+    try {
+      await axios.delete(`/api/medications/${m.id}`);
+      setModal(null);
+      loadMeds();
+    } catch {
+      setError('Could not delete medication. Please try again.');
+    }
   }
 
   const isRx = form.type === 'rx';


### PR DESCRIPTION
Closes #86

## Root cause

`crud.delete_medication` called `db.delete(med)` directly. Postgres enforces FK constraints on `dose_logs.medication_id` and `prescriptions.medication_id` with no `ON DELETE CASCADE`, so any medication with dose history or a prescription would return a 500 and silently fail in the UI (no error was caught or shown).

## Fix

**Backend (`crud.py`):** Before deleting the medication, explicitly delete:
1. All `DoseLog` rows for this medication
2. All `Fill` rows for the medication's prescription (if one exists)
3. The `Prescription` itself (if one exists)
4. Then the `Medication`

No migration needed - this is purely a CRUD-layer fix.

**Frontend (`Settings.jsx`):** Wrap `axios.delete` in a try/catch so errors surface in the modal instead of being silently swallowed. Also updates the confirm dialog to mention that dose history will be removed.

## Test plan
- [ ] Delete a medication that has no dose history - should work as before
- [ ] Delete a medication that has logged doses - should now succeed and remove the history
- [ ] Delete a medication that has a prescription and fill history - should succeed and remove prescription + fills
- [ ] Cancel the confirm dialog - no deletion should occur
- [ ] Verify deleted medication no longer appears in Today, History, or Refills