### PR TITLE
fix(stability): error boundary, history timezone, settings error handling, SW cache key

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { Routes, Route, Link, useLocation, Navigate } from 'react-router';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import { ToastProvider } from './context/ToastContext';
 import ProtectedRoute from './components/ProtectedRoute';
+import ErrorBoundary from './components/ErrorBoundary';
 import Today from './pages/Today';
 import Refills from './pages/Refills';
 import History from './pages/History';
@@ -129,6 +130,7 @@ function AppShell() {
       </header>
 
       <main className="max-w-3xl mx-auto px-4 py-6">
+        <ErrorBoundary>
         <Routes>
           <Route path="/login" element={<Login />} />
           <Route path="/"        element={<ProtectedRoute><Today    /></ProtectedRoute>} />
@@ -137,6 +139,7 @@ function AppShell() {
           <Route path="/settings"element={<ProtectedRoute><Settings /></ProtectedRoute>} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
+        </ErrorBoundary>
       </main>
 
       <footer className="max-w-3xl mx-auto px-4 py-4 mt-2 flex items-center justify-end gap-2 border-t border-gray-200 dark:border-gray-800">

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('Unhandled render error:', error, info);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="min-h-[40vh] flex flex-col items-center justify-center gap-3 px-4 text-center">
+          <p className="text-gray-700 dark:text-gray-200 font-medium">Something went wrong.</p>
+          <p className="text-sm text-gray-400 dark:text-gray-500">
+            {this.state.error.message || 'An unexpected error occurred.'}
+          </p>
+          <button
+            onClick={() => this.setState({ error: null })}
+            className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/pages/History.jsx
+++ b/frontend/src/pages/History.jsx
@@ -2,35 +2,39 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { Link } from 'react-router';
 import axios from 'axios';
 
+function localDateStr(d) {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
 function daysAgo(n) {
   const d = new Date();
   d.setDate(d.getDate() - n);
-  return d.toISOString().slice(0, 10);
+  return localDateStr(d);
 }
 
 function computeStreak(logs, medicationId) {
   const dates = [...new Set(
     logs
       .filter(l => l.medication_id === medicationId)
-      .map(l => l.taken_at.slice(0, 10))
+      .map(l => localDateStr(new Date(l.taken_at)))
   )].sort().reverse();
 
   if (dates.length === 0) return 0;
 
   let streak = 0;
-  let expected = new Date().toISOString().slice(0, 10);
+  let expected = localDateStr(new Date());
 
   for (const d of dates) {
     if (d === expected) {
       streak++;
-      const prev = new Date(expected);
+      const prev = new Date(expected + 'T00:00:00');
       prev.setDate(prev.getDate() - 1);
-      expected = prev.toISOString().slice(0, 10);
+      expected = localDateStr(prev);
     } else if (streak === 0 && d === daysAgo(1)) {
       streak++;
-      const prev = new Date(d);
+      const prev = new Date(d + 'T00:00:00');
       prev.setDate(prev.getDate() - 1);
-      expected = prev.toISOString().slice(0, 10);
+      expected = localDateStr(prev);
     } else {
       break;
     }

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -72,8 +72,12 @@ function SharingModal({ person, onClose }) {
   }
 
   async function removeUser(entry) {
-    await axios.delete(`/api/persons/${person.id}/access/${entry.account_id}`);
-    loadAccess();
+    try {
+      await axios.delete(`/api/persons/${person.id}/access/${entry.account_id}`);
+      loadAccess();
+    } catch (e) {
+      setError(e.response?.data?.detail || 'Could not remove user.');
+    }
   }
 
   return (
@@ -169,8 +173,12 @@ function PersonsTab() {
 
   async function del(p) {
     if (!confirm(`Delete ${p.name}? This will remove all their medication data.`)) return;
-    await axios.delete(`/api/persons/${p.id}`);
-    load();
+    try {
+      await axios.delete(`/api/persons/${p.id}`);
+      load();
+    } catch (e) {
+      showToast(e.response?.data?.detail || 'Could not delete person.', 'error');
+    }
   }
 
   return (
@@ -398,8 +406,12 @@ function MedicationsTab() {
   }
 
   async function toggleActive(m) {
-    await axios.patch(`/api/medications/${m.id}`, { is_active: !m.is_active });
-    loadMeds();
+    try {
+      await axios.patch(`/api/medications/${m.id}`, { is_active: !m.is_active });
+      loadMeds();
+    } catch {
+      showToast('Could not update medication status.', 'error');
+    }
   }
 
   async function deleteMed(m) {
@@ -731,8 +743,12 @@ function PrescriptionsTab() {
 
   async function del(rx) {
     if (!confirm(`Remove prescription for ${rx.medication_name}?`)) return;
-    await axios.delete(`/api/prescriptions/${rx.id}`);
-    load();
+    try {
+      await axios.delete(`/api/prescriptions/${rx.id}`);
+      load();
+    } catch (e) {
+      setLoadError(e.response?.data?.detail || 'Could not remove prescription.');
+    }
   }
 
   return (
@@ -1020,6 +1036,7 @@ function NotificationsTab() {
 
 // ── Contacts tab ──────────────────────────────────────────────────────────────
 function ContactsTab() {
+  const showToast = useToast();
   const [section, setSection]   = useState('providers'); // 'providers' | 'pharmacies'
   const [items, setItems]       = useState([]);
   const [modal, setModal]       = useState(null);
@@ -1069,10 +1086,13 @@ function ContactsTab() {
   }
 
   async function del(item) {
-    const label = isProvider ? 'provider' : 'pharmacy';
     if (!confirm(`Delete ${item.name}?`)) return;
-    await axios.delete(`/api/contacts/${section}/${item.id}`);
-    load();
+    try {
+      await axios.delete(`/api/contacts/${section}/${item.id}`);
+      load();
+    } catch (e) {
+      showToast(e.response?.data?.detail || 'Could not delete.', 'error');
+    }
   }
 
   return (
@@ -1193,6 +1213,7 @@ function InvitesTab() {
   const [expiry, setExpiry]     = useState('');
   const [creating, setCreating] = useState(false);
   const [copied, setCopied]     = useState(null);
+  const [error, setError]       = useState(null);
 
   function load() {
     axios.get('/api/auth/invites').then(r => setInvites(r.data));
@@ -1201,10 +1222,13 @@ function InvitesTab() {
 
   async function create() {
     setCreating(true);
+    setError(null);
     try {
       await axios.post('/api/auth/invites', { expires_in_days: expiry ? Number(expiry) : null });
       setExpiry('');
       load();
+    } catch (e) {
+      setError(e.response?.data?.detail || 'Could not generate invite.');
     } finally {
       setCreating(false);
     }
@@ -1212,8 +1236,12 @@ function InvitesTab() {
 
   async function revoke(id) {
     if (!confirm('Revoke this invite code?')) return;
-    await axios.delete(`/api/auth/invites/${id}`);
-    load();
+    try {
+      await axios.delete(`/api/auth/invites/${id}`);
+      load();
+    } catch (e) {
+      setError(e.response?.data?.detail || 'Could not revoke invite.');
+    }
   }
 
   function copyCode(code) {
@@ -1227,6 +1255,7 @@ function InvitesTab() {
 
   return (
     <div className="space-y-5 max-w-lg">
+      {error && <p className="text-red-500 text-sm">{error}</p>}
       <div>
         <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3">Generate invite code</h3>
         <div className="flex gap-3 items-end">

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,8 +2,11 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { execSync } from 'child_process'
+import { readFileSync, writeFileSync } from 'fs'
+import { resolve } from 'path'
 
 const commitHash = (() => {
+  if (process.env.COMMIT_HASH) return process.env.COMMIT_HASH.slice(0, 7);
   try {
     return execSync('git rev-parse --short HEAD').toString().trim();
   } catch {
@@ -11,8 +14,21 @@ const commitHash = (() => {
   }
 })();
 
+const stampSw = {
+  name: 'stamp-sw',
+  closeBundle() {
+    const swPath = resolve(__dirname, 'dist/sw.js');
+    try {
+      const src = readFileSync(swPath, 'utf-8');
+      writeFileSync(swPath, src.replace("'mc-v1'", `'mc-${commitHash}'`));
+    } catch {
+      // sw.js not present in dev mode
+    }
+  },
+};
+
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), stampSw],
   define: {
     __COMMIT_HASH__: JSON.stringify(commitHash),
   },


### PR DESCRIPTION
## Summary

- **#93** - All silent-failure async operations in Settings now surface errors via toast or inline message: `removeUser`, `del` (persons/prescriptions/contacts), `toggleActive`, `InvitesTab.create`, `InvitesTab.revoke`
- **#94** - History streak calculation now uses local dates instead of UTC dates, fixing wrong streak counts near midnight
- **#95** - Added `ErrorBoundary` component wrapping all routes so unhandled render errors show a recoverable UI instead of a blank screen
- **#96** - Service worker cache key is now stamped with the commit hash at build time via a Vite `closeBundle` plugin, ensuring stale assets are cleared on each deploy

## Test plan

- [ ] Settings: trigger a network error (disable network in devtools) while deleting a person, medication, prescription, or contact - should see a toast or inline error
- [ ] Settings: try revoking/generating an invite with network off - should show inline error
- [ ] History: log a dose late at night, verify streak counts correctly the next morning
- [ ] Build the frontend and confirm `dist/sw.js` contains `mc-<hash>` instead of `mc-v1`
- [ ] Trigger a render error in a page component and verify the error boundary fallback appears with a "Try again" button