### PR TITLE
chore: add personal workflow files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ Thumbs.db
 
 # AI tooling — never commit these
 .claude/
+CLAUDE.md
+DECISIONS.md


### PR DESCRIPTION
Adds two filename patterns to .gitignore that should not be tracked in version control.