### PR TITLE
Allow logging multiple doses per day for multi-dose schedules

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import Modal from '../components/Modal';
 import { useAuth } from '../context/AuthContext';
 import { useToast } from '../context/ToastContext';
+import { apiErrorMessage } from '../utils/apiError';
 
 const TABS = ['People', 'Medications', 'Prescriptions', 'Contacts', 'Notifications', 'Invites', 'Account', 'Activity'];
 const SCHEDULES = ['morning', 'twice_daily', 'evening', 'three_times_daily', 'every_other_day', 'weekly', 'monthly', 'as_needed'];
@@ -65,7 +66,7 @@ function SharingModal({ person, onClose }) {
       setNewUsername('');
       loadAccess();
     } catch (e) {
-      setError(e.response?.data?.detail || 'Could not add user.');
+      setError(apiErrorMessage(e, 'Could not add user.'));
     } finally {
       setAdding(false);
     }
@@ -76,7 +77,7 @@ function SharingModal({ person, onClose }) {
       await axios.delete(`/api/persons/${person.id}/access/${entry.account_id}`);
       loadAccess();
     } catch (e) {
-      setError(e.response?.data?.detail || 'Could not remove user.');
+      setError(apiErrorMessage(e, 'Could not remove user.'));
     }
   }
 
@@ -177,7 +178,7 @@ function PersonsTab() {
       await axios.delete(`/api/persons/${p.id}`);
       load();
     } catch (e) {
-      showToast(e.response?.data?.detail || 'Could not delete person.', 'error');
+      showToast(apiErrorMessage(e, 'Could not delete person.'), 'error');
     }
   }
 
@@ -399,7 +400,7 @@ function MedicationsTab() {
       loadMeds();
       showToast(modal === 'add' ? 'Medication added' : 'Medication updated');
     } catch (e) {
-      setError(e.response?.data?.detail || 'Could not save.');
+      setError(apiErrorMessage(e, 'Could not save.'));
     } finally {
       setSaving(false);
     }
@@ -446,8 +447,15 @@ function MedicationsTab() {
         </div>
       )}
 
-      <div className="flex justify-end">
-        <button onClick={openAdd} className="px-3 py-1.5 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700">
+      <div className="flex justify-end items-center gap-3">
+        {!selectedPerson && (
+          <p className="text-xs text-gray-400 dark:text-gray-500">Add a person before adding medications.</p>
+        )}
+        <button
+          onClick={openAdd}
+          disabled={!selectedPerson}
+          className="px-3 py-1.5 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
           Add medication
         </button>
       </div>
@@ -681,7 +689,7 @@ function PrescriptionsTab() {
       );
       setAllMeds(eligible);
     } catch (e) {
-      setLoadError(e.response?.data?.detail || 'Could not load prescriptions.');
+      setLoadError(apiErrorMessage(e, 'Could not load prescriptions.'));
     }
   }
 
@@ -735,7 +743,7 @@ function PrescriptionsTab() {
       load();
       showToast('Prescription updated');
     } catch (e) {
-      setError(e.response?.data?.detail || 'Could not save.');
+      setError(apiErrorMessage(e, 'Could not save.'));
     } finally {
       setSaving(false);
     }
@@ -747,7 +755,7 @@ function PrescriptionsTab() {
       await axios.delete(`/api/prescriptions/${rx.id}`);
       load();
     } catch (e) {
-      setLoadError(e.response?.data?.detail || 'Could not remove prescription.');
+      setLoadError(apiErrorMessage(e, 'Could not remove prescription.'));
     }
   }
 
@@ -1079,7 +1087,7 @@ function ContactsTab() {
       setModal(null);
       load();
     } catch (e) {
-      setError(e.response?.data?.detail || 'Could not save.');
+      setError(apiErrorMessage(e, 'Could not save.'));
     } finally {
       setSaving(false);
     }
@@ -1091,7 +1099,7 @@ function ContactsTab() {
       await axios.delete(`/api/contacts/${section}/${item.id}`);
       load();
     } catch (e) {
-      showToast(e.response?.data?.detail || 'Could not delete.', 'error');
+      showToast(apiErrorMessage(e, 'Could not delete.'), 'error');
     }
   }
 
@@ -1228,7 +1236,7 @@ function InvitesTab() {
       setExpiry('');
       load();
     } catch (e) {
-      setError(e.response?.data?.detail || 'Could not generate invite.');
+      setError(apiErrorMessage(e, 'Could not generate invite.'));
     } finally {
       setCreating(false);
     }
@@ -1240,7 +1248,7 @@ function InvitesTab() {
       await axios.delete(`/api/auth/invites/${id}`);
       load();
     } catch (e) {
-      setError(e.response?.data?.detail || 'Could not revoke invite.');
+      setError(apiErrorMessage(e, 'Could not revoke invite.'));
     }
   }
 
@@ -1364,7 +1372,7 @@ function AccountTab() {
       login(res.data);
       setUsernameMsg({ ok: true, text: 'Username updated.' });
     } catch (e) {
-      setUsernameMsg({ ok: false, text: e.response?.data?.detail || 'Could not update username.' });
+      setUsernameMsg({ ok: false, text: apiErrorMessage(e, 'Could not update username.') });
     } finally {
       setUsernameSaving(false);
     }
@@ -1383,7 +1391,7 @@ function AccountTab() {
       setPw({ current: '', next: '', confirm: '' });
       setPwMsg({ ok: true, text: 'Password changed.' });
     } catch (e) {
-      setPwMsg({ ok: false, text: e.response?.data?.detail || 'Could not change password.' });
+      setPwMsg({ ok: false, text: apiErrorMessage(e, 'Could not change password.') });
     } finally {
       setPwSaving(false);
     }

--- a/frontend/src/pages/Today.jsx
+++ b/frontend/src/pages/Today.jsx
@@ -13,6 +13,17 @@ const SCHEDULE_LABEL = {
   monthly:           'Monthly',
   as_needed:         'As Needed',
 };
+// Expected doses per day for each schedule. Drives how many times "Took it"
+// can be tapped before a medication is considered done for the day.
+const DOSES_PER_DAY = {
+  morning:           1,
+  twice_daily:       2,
+  evening:           1,
+  three_times_daily: 3,
+  every_other_day:   1,
+  weekly:            1,
+  monthly:           1,
+};
 
 // Returns YYYY-MM-DD for today in the browser's local timezone.
 function todayISO() {
@@ -286,49 +297,78 @@ export default function Today() {
                   );
                 }
 
-                // Regular scheduled med: one-and-done per day
-                const log = todayLogs[0] ?? null;
+                // Regular scheduled med: allow up to the schedule's expected doses per day
+                const expected = DOSES_PER_DAY[schedule] ?? 1;
+                const done = todayLogs.length >= expected;
+                const lastLog = todayLogs[0] ?? null;
                 return (
                   <li
                     key={med.id}
                     className={`flex items-center justify-between rounded-xl px-4 py-3 shadow-sm transition-colors ${
-                      taken
+                      done
                         ? 'bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800'
                         : 'bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700'
                     }`}
                   >
                     <div className="min-w-0">
-                      <p className={`font-medium truncate ${taken ? 'text-green-800 dark:text-green-300' : 'text-gray-800 dark:text-gray-100'}`}>
+                      <p className={`font-medium truncate ${done ? 'text-green-800 dark:text-green-300' : 'text-gray-800 dark:text-gray-100'}`}>
                         {med.name}
                       </p>
                       {med.dose_amount && (
                         <p className="text-sm text-gray-400 dark:text-gray-500">{med.dose_amount}</p>
                       )}
                       {taken && (
-                        <p className="text-xs text-green-600 dark:text-green-400 mt-0.5">
-                          Taken at {formatTime(log.taken_at)}
-                        </p>
+                        <div className="mt-1 flex flex-wrap items-center gap-2">
+                          {expected > 1 && (
+                            <span className="text-xs font-medium text-green-600 dark:text-green-400">
+                              Taken {todayLogs.length} of {expected} today
+                            </span>
+                          )}
+                          {expected === 1 && (
+                            <span className="text-xs text-green-600 dark:text-green-400">
+                              Taken at {formatTime(lastLog.taken_at)}
+                            </span>
+                          )}
+                          {expected > 1 && [...todayLogs].reverse().map((log, i) => (
+                            <span key={log.id} className="flex items-center gap-1">
+                              <span className="text-xs text-gray-400 dark:text-gray-500">{formatTime(log.taken_at)}</span>
+                              {i === 0 && (
+                                <button
+                                  onClick={() => handleUndo(log)}
+                                  className="text-xs text-gray-300 dark:text-gray-600 hover:text-red-500 dark:hover:text-red-400 transition-colors"
+                                  title="Undo last dose"
+                                >
+                                  ×
+                                </button>
+                              )}
+                            </span>
+                          ))}
+                        </div>
                       )}
                     </div>
 
                     <div className="ml-4 shrink-0">
-                      {taken ? (
-                        <div className="flex items-center gap-2">
+                      {done ? (
+                        expected === 1 ? (
+                          <div className="flex items-center gap-2">
+                            <span className="text-green-500 text-xl">✓</span>
+                            <button
+                              onClick={() => handleUndo(lastLog)}
+                              className="text-xs text-gray-400 hover:text-red-500 dark:text-gray-500 dark:hover:text-red-400 transition-colors"
+                            >
+                              Undo
+                            </button>
+                          </div>
+                        ) : (
                           <span className="text-green-500 text-xl">✓</span>
-                          <button
-                            onClick={() => handleUndo(log)}
-                            className="text-xs text-gray-400 hover:text-red-500 dark:text-gray-500 dark:hover:text-red-400 transition-colors"
-                          >
-                            Undo
-                          </button>
-                        </div>
+                        )
                       ) : (
                         <button
                           onClick={() => handleLog(med)}
                           disabled={busy}
                           className="px-4 py-1.5 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
                         >
-                          {busy ? '…' : 'Took it'}
+                          {busy ? '…' : expected > 1 ? `Took it (${todayLogs.length}/${expected})` : 'Took it'}
                         </button>
                       )}
                     </div>

--- a/frontend/src/utils/apiError.js
+++ b/frontend/src/utils/apiError.js
@@ -1,0 +1,13 @@
+// FastAPI returns `detail` as a plain string for HTTPException, but as an
+// array of { type, loc, msg, input } objects for Pydantic validation errors
+// (422 responses). Rendering that array directly as a React child crashes
+// the app, so this normalizes either shape into a displayable string.
+export function apiErrorMessage(error, fallback = 'Something went wrong.') {
+  const detail = error?.response?.data?.detail;
+  if (!detail) return fallback;
+  if (typeof detail === 'string') return detail;
+  if (Array.isArray(detail)) {
+    return detail.map(d => d?.msg || fallback).join(' ');
+  }
+  return fallback;
+}


### PR DESCRIPTION
## Summary
- Today screen now allows logging up to the expected number of doses per day for twice-daily and three-times-daily schedules, instead of capping every schedule at one dose ("Taken 2 of 3 today" progress with per-dose timestamps and undo, same pattern as as-needed meds)
- Fixes a crash where a FastAPI validation error (422) rendered its raw detail array directly as a React child instead of a message, via a shared `apiErrorMessage` helper used across Settings.jsx
- Disables "Add medication" when no person exists/selected, preventing a guaranteed validation failure (`person_id: null`)

Closes #114

## Test plan
- [x] Manually verified on Today screen: added a med with "Three Times Daily" schedule, confirmed "Took it" can be tapped 3 times with progress shown, then disables
- [x] Verified single-dose schedules (morning/evening/etc.) unchanged
- [x] Verified as-needed meds unaffected
- [x] `npx vite build` clean after each change
- [x] Manually triggered a validation error and confirmed a readable message now shows instead of a crash
- [x] Verified "Add medication" is disabled with no person selected