### PR TITLE
ci: add semantic-release for automated versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+on:
+  workflow_run:
+    workflows: ["Docker Image CI"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      released: ${{ steps.release.outputs.released }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
+      - name: Install release dependencies
+        run: npm install --no-save semantic-release @semantic-release/changelog @semantic-release/exec @semantic-release/git
+
+      - name: Release
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npx semantic-release
+          if [ -f .semrelease-version ]; then
+            echo "version=$(cat .semrelease-version)" >> "$GITHUB_OUTPUT"
+            echo "released=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  tag-image:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Pull latest and tag with released version
+        run: |
+          docker pull ${{ vars.DOCKER_USERNAME }}/medicine-cabinet:latest
+          docker tag ${{ vars.DOCKER_USERNAME }}/medicine-cabinet:latest \
+            ${{ vars.DOCKER_USERNAME }}/medicine-cabinet:${{ needs.release.outputs.version }}
+          docker push ${{ vars.DOCKER_USERNAME }}/medicine-cabinet:${{ needs.release.outputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ node_modules/
 frontend/dist/
 frontend/.vite/
 
+# semantic-release
+.semrelease-version
+
 # OS
 .DS_Store
 Thumbs.db

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,27 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
+      }
+    ],
+    "@semantic-release/github",
+    [
+      "@semantic-release/exec",
+      {
+        "successCmd": "echo ${nextRelease.version} > .semrelease-version"
+      }
+    ]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "medicine-cabinet",
+  "private": true,
+  "devDependencies": {
+    "semantic-release": "^24.2.0",
+    "@semantic-release/changelog": "^6.0.3",
+    "@semantic-release/exec": "^6.0.3",
+    "@semantic-release/git": "^10.0.1"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds semantic-release, driven off Conventional Commit history on `main`
- New `release.yml` workflow runs after `Docker Image CI` succeeds, generating `CHANGELOG.md`, a GitHub Release + tag, and tagging the built DockerHub image with the released version
- `fix:` -> patch, `feat:` -> minor, `!`/`BREAKING CHANGE:` -> major; other types produce no release
- Root `package.json` exists only to pin semantic-release's own CI dependencies - not the frontend package, never published

## Test plan
- [ ] Merge to `main` and confirm `Docker Image CI` then `Release` both run
- [ ] Confirm `CHANGELOG.md` is created and a GitHub Release appears with the correct version bump
- [ ] Confirm `dogiakos/medicine-cabinet:<version>` tag appears on DockerHub